### PR TITLE
Changes for building Docker image for M-Lab platform

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,22 @@
 from fedora:30
 MAINTAINER Guilherme Martins, gmartins princeton edu
-RUN yum update && yum upgrade -y 
-RUN yum install -y sudo binutils initscripts iproute iputils findutils mlocate cronie vim curl wget links net-tools nc python python-simplejson traceroute 
+RUN yum upgrade -y
+RUN yum install -y sudo binutils initscripts iproute iputils findutils mlocate cronie vim curl wget links net-tools nc python python-simplejson traceroute chkconfig
 RUN yum install -y glibc tcp_wrappers-libs.i686 tcp_wrappers libstdc++.i686
 RUN useradd gt_bismark_unpriv && usermod -L gt_bismark_unpriv
 COPY sudoers /etc/sudoers
 COPY sudoers.bismark /etc/sudoers.d/
 COPY rpm /root/rpm
-RUN rpm -i --nodeps /root/rpm/openssl098e-0.9.8e-29.el7.centos.3.i686.rpm 
-#RUN rpm -i /root/rpm/ncurses-base-6.1-10.20180923.fc30.noarch.rpm
-RUN rpm -i /root/rpm/ncurses-libs-6.1-10.20180923.fc30.i686.rpm
-RUN rpm -i /root/rpm/compat-readline5-5.2-32.fc29.i686.rpm
-RUN rpm -i /root/rpm/ditg-2.8.0-0bismark4.rc1.fc8.i386.rpm
-RUN rpm -i /root/rpm/iperf-2.0.4-1bismark2.fc8.i386.rpm 
-RUN rpm -i /root/rpm/netperf-2.4.5-1bismark4.fc8.i386.rpm
-RUN rpm -i /root/rpm/paris-traceroute-0.92-3.fc8.i386.rpm
-RUN rpm -i /root/rpm/shaperprobe-server-0.1-1bismark3.fc8.i386.rpm
-RUN rpm -i /root/rpm/socat-1.7.1.3-1bismark3.fc8.i386.rpm
-RUN rpm -i /root/rpm/bismark-mserver-0.1.14-1.fc8.noarch.rpm
-RUN systemctl enable crond.service
-RUN /sbin/chkconfig --level 2345 bismark-mserver on
+RUN rpm -i --nodeps --nosignature /root/rpm/openssl098e-0.9.8e-29.el7.centos.3.i686.rpm
+RUN rpm -i --nosignature /root/rpm/ncurses-libs-6.1-10.20180923.fc30.i686.rpm
+RUN rpm -i --nosignature /root/rpm/compat-readline5-5.2-32.fc29.i686.rpm
+RUN rpm -i --nosignature /root/rpm/ditg-2.8.0-0bismark4.rc1.fc8.i386.rpm
+RUN rpm -i --nosignature /root/rpm/iperf-2.0.4-1bismark2.fc8.i386.rpm
+RUN rpm -i --nosignature /root/rpm/netperf-2.4.5-1bismark4.fc8.i386.rpm
+RUN rpm -i --nosignature /root/rpm/paris-traceroute-0.92-3.fc8.i386.rpm
+RUN rpm -i --nosignature /root/rpm/shaperprobe-server-0.1-1bismark3.fc8.i386.rpm
+RUN rpm -i --nosignature /root/rpm/socat-1.7.1.3-1bismark3.fc8.i386.rpm
+RUN rpm -i --nosignature /root/rpm/bismark-mserver-0.1.14-1.fc8.noarch.rpm
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 EXPOSE 1430 55005 12865 9000 5001 1100 1101 1102

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@
 while true;
 do
   for port in 1100 1101 1102 1430 5001 9000 12865 55005; do
-    ss -ltn | awk '{print $4}' | grep $port
+    ss -ltn | awk '{print $4}' | grep $port > /dev/null
     if [[ "$?" -ne "0" ]]; then
       /etc/init.d/bismark-mserver restart
       echo "Bismark MServer restarted."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,9 +2,13 @@
 
 while true;
 do
-  if [ $(netstat -lntp | tail -n+3 | wc -l) != 8 ]; then
-	  /etc/init.d/bismark-mserver restart
-	  echo "Bismark MServer restarted."
-  fi
+  for port in 1100 1101 1102 1430 5001 9000 12865 55005; do
+    ss -ltn | awk '{print $4}' | grep $port
+    if [[ "$?" -ne "0" ]]; then
+      /etc/init.d/bismark-mserver restart
+      echo "Bismark MServer restarted."
+      break
+    fi
+  done
   sleep 5
 done


### PR DESCRIPTION
@ggmartins: There are some changes either required or suggested to get the Docker image to build, or improve a few things.

* I modified `entrypoint.sh` with a loop that will be more reliable. We run several sidecar containers in every experiment pod which listen on various ports. The simple `grep` for a particular count of listening ports wasn't working as expected (server was restarting every 5 seconds) because of these other containers.

* I removed the `systemctl` and `chkconfig` commands from the Docker. Because this is just a container, systemd isn't running in there. For `chkconfig`, there is no concept of runlevels in the container.

*  The addition of `--nosignature` just avoids a bunch of warnings.